### PR TITLE
포스트 업로드 후 쿼리 캐싱 처리 로직 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,13 @@ yarn install
 COPY . .
 RUN yarn build
 
-# # Stage 2: Create the final image
-# FROM node:18.17.0-alpine3.17
-# WORKDIR /app
+# Stage 2: Create the final image
+FROM node:18.17.0-alpine3.17
+WORKDIR /app
 
-# COPY --from=build /app/package.json /app/package-lock.json ./
-# COPY --from=build /app/.next ./.next
-# COPY --from=build /app/public ./public
-
-# RUN npm install --only=prod --legacy-peer-deps
+# COPY --from=build /app/package.json ./
+# build 스테이지에서 ./next 와 ./public만 복사해오기
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/public ./public
 
 CMD [ "yarn", "start" ]

--- a/src/query/post/useUploadPost.ts
+++ b/src/query/post/useUploadPost.ts
@@ -36,8 +36,12 @@ const useUploadPost = () => {
     // Always refetch after error or success:
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: [QueryKey.Post] });
+    },
+    onSuccess: () => {
       //새 게시글 추가 후 페이지네이션 데이터 다시 요청
       queryClient.resetQueries({ queryKey: [QueryKey.GetRecentPages] });
+      //임시 저장된 쿼리 캐시 삭제
+      queryClient.removeQueries({ queryKey: [QueryKey.TempPost] });
     },
   });
 


### PR DESCRIPTION
### 개요
- 서버에서 포스트 업로드 후 임시저장 포스트 삭제로 로직 변경 -> 클라이언트에서  리액트 쿼리 캐싱 처리 로직 변경

### 작업 사항
1. mutation onSuccess조건으로 임시저장 캐싱 삭제
2. 도커파일 로직 변경 -> --only=prod 옵션 추가/ 멀티스테이지에서 필요한 부분만 복사해오기

### 고려 사항
1. 